### PR TITLE
Selected file sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To sync the local context to a remote:
 
 As with `cc-sync [from]`, the remote relative path can be specified.
 
-`cc-sync [from]` and `cc-sync to` are `rsync` wrappers. By default `rsync` commands are additive, consolidating context across machines. Using the `--delete` option (without `--find-args`, see below) will clobber the destination with the source.
+`cc-sync [from]` and `cc-sync to` are `rsync` wrappers. By default `rsync` commands are additive, consolidating context across machines. Using the `--delete` option (*without* `--find-args`, see below) will clobber the destination with the source.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 

--- a/README.md
+++ b/README.md
@@ -49,10 +49,9 @@ A backup of existing destination context is created before syncing when files wo
 
 ### Selecting what files from the source are synced
 
-- `--find-args '<expression>'` writes the output of `find <expression>` to `/tmp` for `rsync --files-from <file-list>`
-- `--modified-within <days>` is equivalent to `--find-args '-type f -mtime -<days>'`
-- `--modified-within` and `--find-args` are mutually exclusive
-- `--delete` with either will *not* delete files not in the `find` output
+- `--find-args '<expression>'` invokes `rsync --files-from <list>` with the output of `find <expression>`
+- `--modified-within <days>` is an alias for `--find-args '-type f -mtime -<days>'`
+- Combining `--delete` with either will *not* delete unselected destination files.
 
 Examples:
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As with `cc-sync [from]`, the remote relative path can be specified.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
-### Limiting what files from the source are synced
+### Selecting what files from the source are synced
 
 - `--find-args '<expression>'` writes the output of `find <expression>` to `/tmp` for `rsync --files-from <file-list>`
 - `--modified-within <days>` is equivalent to `--find-args '-type f -mtime -<days>'`

--- a/README.md
+++ b/README.md
@@ -57,8 +57,8 @@ A backup of existing destination context is created before syncing when files wo
 Examples:
 
 ```sh
-~/code/catbutt$ cc-sync --modified-within-days 3 xicamatl
-~/code/catbutt$ cc-sync to --find-expr "-type f -name '*.jsonl'" --dry-run xicamatl
+~/code/catbutt$ cc-sync --modified-within 3 xicamatl
+~/code/catbutt$ cc-sync to --find-args "-type f -name '*.jsonl'" --dry-run xicamatl
 ```
 
 ## Listing context directory contents
@@ -76,9 +76,9 @@ Examples:
     - `--dry-run`, `-n`: preview what would be transferred
     - `--delete`: clobber the destination, removing context not present in the source
     - `-z`, `--compress`: compress data during transfer
-  - Bounded sync options:
-    - `--modified-within-days <days>`: select regular files matching `find . -type f -mtime -<days>`
-    - `--find-expr '<expression>'`: select files using `find . <expression>`
+  - File selection options:
+    - `--modified-within <days>`: select regular files matching `find . -type f -mtime -<days>`
+    - `--find-args '<expression>'`: select files using `find . <expression>`
   - Local context directory determined by CWD
   - Remote context determined by the same relative path unless `:path` is specified
   - If `from` or `to` is omitted, `from` is assumed

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As with `cc-sync [from]`, the remote relative path can be specified.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
-### Selecting context files to sync with `find`
+### Selecting context files to sync with `find` arguments
 
 - `--find-args '<expression>'` invokes `rsync --files-from <list>` with the output of `find <expression>`
 - `--modified-within <days>` is an alias for `--find-args '-type f -mtime -<days>'`

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As with `cc-sync [from]`, the remote relative path can be specified.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
-### Selecting what files from the source are synced
+### Limiting what files are copied from `rsync` source
 
 - `--find-args '<expression>'` invokes `rsync --files-from <list>` with the output of `find <expression>`
 - `--modified-within <days>` is an alias for `--find-args '-type f -mtime -<days>'`

--- a/README.md
+++ b/README.md
@@ -47,6 +47,23 @@ As with `cc-sync [from]`, the remote relative path can be specified.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
+### Bounded sync
+
+Bounded sync limits which files are copied without pruning the destination.
+
+- `--modified-within-days <days>` is shorthand for `find . -type f -mtime -<days>`
+- `--find-expr '<expression>'` appends the expression after `find .`
+- `--modified-within-days` and `--find-expr` are mutually exclusive
+- if nothing matches, `cc-sync` prints a no-op message and exits successfully without invoking `rsync`
+- if `--delete` is also passed, deletion still follows normal `rsync` semantics
+
+Examples:
+
+```sh
+~/code/catbutt$ cc-sync to --modified-within-days 7 xicamatl
+~/code/catbutt$ cc-sync to --find-expr "-type f -name '*.jsonl'" --dry-run xicamatl
+```
+
 ## Listing context directory contents
 
 `cc-sync list` shows the local context directory for the CWD with `ls -l -t`.
@@ -62,6 +79,9 @@ A backup of existing destination context is created before syncing when files wo
     - `--dry-run`, `-n`: preview what would be transferred
     - `--delete`: clobber the destination, removing context not present in the source
     - `-z`, `--compress`: compress data during transfer
+  - Bounded sync options:
+    - `--modified-within-days <days>`: select regular files matching `find . -type f -mtime -<days>`
+    - `--find-expr '<expression>'`: select files using `find . <expression>`
   - Local context directory determined by CWD
   - Remote context determined by the same relative path unless `:path` is specified
   - If `from` or `to` is omitted, `from` is assumed

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Shell functions for syncing and backing up Claude Code project context across machines.
 
-## Syncing contexts between machines
+## Syncing context between machines
 
 `cc-sync` (or `cc-sync from`) syncs the context for the CWD in `~/.claude/projects` from a remote.
 
@@ -49,7 +49,7 @@ A backup of existing destination context is created before syncing when files wo
 
 ### Limiting what files from the source are synced
 
-- `--find-args '<expression>'` writes the output of `find <expression>` to a file for `--files-from` in the `rsync` command
+- `--find-args '<expression>'` uses the output of `find <expression>` for `--files-from <file>` in the `rsync` command
 - `--modified-within <days>` is equivalent to `--find-args '-type f -mtime -<days>'`
 - `--modified-within` and `--find-args` are mutually exclusive
 - `--delete` with either will *not* delete files not in the `find` output

--- a/README.md
+++ b/README.md
@@ -43,24 +43,21 @@ To sync the local context to a remote:
 
 As with `cc-sync [from]`, the remote relative path can be specified.
 
-`cc-sync [from]` and `cc-sync to` are `rsync` wrappers. By default `rsync` commands are additive, consolidating context across machines. Using the `--delete` option will clobber the destination with the source.
+`cc-sync [from]` and `cc-sync to` are `rsync` wrappers. By default `rsync` commands are additive, consolidating context across machines. Using the `--delete` option (without `--files-from`, see below) will clobber the destination with the source.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
-### Bounded sync
+### Limiting what files from the source are synced
 
-Bounded sync limits which files are copied without pruning the destination.
-
-- `--modified-within-days <days>` is shorthand for `find . -type f -mtime -<days>`
-- `--find-expr '<expression>'` appends the expression after `find .`
-- `--modified-within-days` and `--find-expr` are mutually exclusive
-- if nothing matches, `cc-sync` prints a no-op message and exits successfully without invoking `rsync`
-- if `--delete` is also passed, deletion still follows normal `rsync` semantics
+- `--find-args '<expression>'` writes the output of `find <expression>` to a file for `--files-from` in the `rsync` command
+- `--modified-within <days>` is equivalent to `--find-args '-type f -mtime -<days>'`
+- `--modified-within` and `--find-args` are mutually exclusive
+- `--delete` with either will *not* delete files not in the `find` output
 
 Examples:
 
 ```sh
-~/code/catbutt$ cc-sync to --modified-within-days 7 xicamatl
+~/code/catbutt$ cc-sync --modified-within-days 3 xicamatl
 ~/code/catbutt$ cc-sync to --find-expr "-type f -name '*.jsonl'" --dry-run xicamatl
 ```
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A backup of existing destination context is created before syncing when files wo
 
 ### Limiting what files from the source are synced
 
-- `--find-args '<expression>'` uses the output of `find <expression>` for `--files-from <file>` in the `rsync` command
+- `--find-args '<expression>'` writes the output of `find <expression>` to `/tmp` for `--files-from <file>` in the `rsync` command
 - `--modified-within <days>` is equivalent to `--find-args '-type f -mtime -<days>'`
 - `--modified-within` and `--find-args` are mutually exclusive
 - `--delete` with either will *not* delete files not in the `find` output

--- a/README.md
+++ b/README.md
@@ -43,7 +43,7 @@ To sync the local context to a remote:
 
 As with `cc-sync [from]`, the remote relative path can be specified.
 
-`cc-sync [from]` and `cc-sync to` are `rsync` wrappers. By default `rsync` commands are additive, consolidating context across machines. Using the `--delete` option (without `--files-from`, see below) will clobber the destination with the source.
+`cc-sync [from]` and `cc-sync to` are `rsync` wrappers. By default `rsync` commands are additive, consolidating context across machines. Using the `--delete` option (without `--find-args`, see below) will clobber the destination with the source.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As with `cc-sync [from]`, the remote relative path can be specified.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
-### Selecting context files to sync with `find` arguments
+### Selecting what files to sync with `find` arguments
 
 - `--find-args '<expression>'` invokes `rsync --files-from <list>` with the output of `find <expression>`
 - `--modified-within <days>` is an alias for `--find-args '-type f -mtime -<days>'`

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ A backup of existing destination context is created before syncing when files wo
 
 ### Limiting what files from the source are synced
 
-- `--find-args '<expression>'` writes the output of `find <expression>` to `/tmp` for `--files-from <file>` in the `rsync` command
+- `--find-args '<expression>'` writes the output of `find <expression>` to `/tmp` for `rsync --files-from <file-list>`
 - `--modified-within <days>` is equivalent to `--find-args '-type f -mtime -<days>'`
 - `--modified-within` and `--find-args` are mutually exclusive
 - `--delete` with either will *not* delete files not in the `find` output

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ As with `cc-sync [from]`, the remote relative path can be specified.
 
 A backup of existing destination context is created before syncing when files would be transferred, except with `--dry-run`.
 
-### Limiting what files are copied from `rsync` source
+### Selecting context files to sync with `find`
 
 - `--find-args '<expression>'` invokes `rsync --files-from <list>` with the output of `find <expression>`
 - `--modified-within <days>` is an alias for `--find-args '-type f -mtime -<days>'`

--- a/claude-context.sh
+++ b/claude-context.sh
@@ -180,7 +180,7 @@ _cc_sync_validate_modified_within_days() {
     esac
 }
 
-_cc_sync_normalize_manifest() {
+_cc_sync_normalize_list_file() {
     local input_path="$1"
     local output_path="$2"
     local base_path="${3:-}"
@@ -203,70 +203,43 @@ _cc_sync_normalize_manifest() {
     done < "$input_path"
 }
 
-_cc_sync_write_local_manifest() {
+_cc_sync_write_local_list_file() {
     local context_path="$1"
-    local manifest_path="$2"
-    local selector_mode="$3"
-    local selector_value="$4"
-    local raw_manifest_path
+    local output_path="$2"
+    local find_args="$3"
+    local raw_output_path
 
-    raw_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-local-find.XXXXXX") || return 1
+    raw_output_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-local-find.XXXXXX") || return 1
 
     (
         cd "$context_path" || exit 1
-
-        case "$selector_mode" in
-        modified_within_days)
-            find . -type f -mtime -"${selector_value}" -print
-            ;;
-        find_args)
-            eval "find . ${selector_value}"
-            ;;
-        *)
-            echo "Unsupported bounded selector: $selector_mode"
-            exit 1
-            ;;
-        esac
-    ) > "$raw_manifest_path" || {
-        rm -f "$raw_manifest_path"
+        eval "find . ${find_args}"
+    ) > "$raw_output_path" || {
+        rm -f "$raw_output_path"
         return 1
     }
 
-    _cc_sync_normalize_manifest "$raw_manifest_path" "$manifest_path" "$context_path"
-    rm -f "$raw_manifest_path"
+    _cc_sync_normalize_list_file "$raw_output_path" "$output_path" "$context_path"
+    rm -f "$raw_output_path"
 }
 
-_cc_sync_write_remote_manifest() {
+_cc_sync_write_remote_list_file() {
     local remote_host="$1"
     local remote_context_path="$2"
-    local manifest_path="$3"
-    local selector_mode="$4"
-    local selector_value="$5"
-    local raw_manifest_path
+    local output_path="$3"
+    local find_args="$4"
+    local raw_output_path
 
-    raw_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || return 1
+    raw_output_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || return 1
 
-    ssh "$remote_host" sh -s -- "$remote_context_path" "$selector_mode" "$selector_value" <<'EOF' > "$raw_manifest_path" || {
+    ssh "$remote_host" sh -s -- "$remote_context_path" "$find_args" <<'EOF' > "$raw_output_path" || {
 context_path="$1"
-selector_mode="$2"
-selector_value="$3"
-raw_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || exit 1
+find_args="$2"
+raw_output_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || exit 1
 
 cd "$context_path" || exit 1
 
-case "$selector_mode" in
-modified_within_days)
-    find . -type f -mtime -"${selector_value}" -print > "$raw_manifest_path"
-    ;;
-find_args)
-    eval "find . ${selector_value}" > "$raw_manifest_path"
-    ;;
-*)
-    echo "Unsupported bounded selector: $selector_mode" >&2
-    rm -f "$raw_manifest_path"
-    exit 1
-    ;;
-esac
+eval "find . ${find_args}" > "$raw_output_path"
 
 while IFS= read -r relative_path; do
     relative_path="${relative_path#./}"
@@ -280,70 +253,69 @@ while IFS= read -r relative_path; do
     fi
 
     printf '%s\n' "$relative_path"
-done < "$raw_manifest_path"
+done < "$raw_output_path"
 
-rm -f "$raw_manifest_path"
+rm -f "$raw_output_path"
 EOF
-        rm -f "$raw_manifest_path"
+        rm -f "$raw_output_path"
         return 1
     }
 
-    _cc_sync_normalize_manifest "$raw_manifest_path" "$manifest_path"
-    rm -f "$raw_manifest_path"
+    _cc_sync_normalize_list_file "$raw_output_path" "$output_path"
+    rm -f "$raw_output_path"
 }
 
-_cc_sync_prepare_bounded_manifest() {
+_cc_sync_prepare_list_file() {
     local direction="$1"
     local local_context_path="$2"
     local remote_host="$3"
     local remote_context_path="$4"
-    local selector_mode="$5"
-    local selector_value="$6"
-    local count
+    local find_args="$5"
+    local file_count
 
-    bounded_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-manifest.XXXXXX") || return 1
+    list_file_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-list-file.XXXXXX") || return 1
 
     case "$direction" in
     to)
-        _cc_sync_write_local_manifest "$local_context_path" "$bounded_manifest_path" "$selector_mode" "$selector_value" || {
-            rm -f "$bounded_manifest_path"
-            bounded_manifest_path=""
+        _cc_sync_write_local_list_file "$local_context_path" "$list_file_path" "$find_args" || {
+            rm -f "$list_file_path"
+            list_file_path=""
             return 1
         }
         ;;
     from)
-        _cc_sync_write_remote_manifest "$remote_host" "$remote_context_path" "$bounded_manifest_path" "$selector_mode" "$selector_value" || {
-            rm -f "$bounded_manifest_path"
-            bounded_manifest_path=""
+        _cc_sync_write_remote_list_file "$remote_host" "$remote_context_path" "$list_file_path" "$find_args" || {
+            rm -f "$list_file_path"
+            list_file_path=""
             return 1
         }
         ;;
     *)
         echo "Unsupported sync direction: $direction"
-        rm -f "$bounded_manifest_path"
-        bounded_manifest_path=""
+        rm -f "$list_file_path"
+        list_file_path=""
         return 1
         ;;
     esac
 
-    count=$(wc -l < "$bounded_manifest_path")
-    bounded_manifest_count="${count//[[:space:]]/}"
+    file_count=$(wc -l < "$list_file_path")
+    file_count="${file_count//[[:space:]]/}"
 
-    echo "Selected ${bounded_manifest_count} files:"
-    cat "$bounded_manifest_path"
+    echo "Selected ${file_count} files:"
+    cat "$list_file_path"
 
-    if [ "$bounded_manifest_count" -eq 0 ]; then
+    if [ "$file_count" -eq 0 ]; then
         echo "Nothing matched. Nothing to sync."
-        rm -f "$bounded_manifest_path"
-        bounded_manifest_path=""
+        rm -f "$list_file_path"
+        list_file_path=""
         return 2
     fi
 }
 
-_cc_sync_cleanup_bounded_manifest() {
-    if [ -n "$bounded_manifest_path" ]; then
-        rm -f "$bounded_manifest_path"
-        bounded_manifest_path=""
+_cc_sync_cleanup_list_file() {
+    if [ -n "$list_file_path" ]; then
+        rm -f "$list_file_path"
+        list_file_path=""
     fi
 }
 
@@ -352,8 +324,7 @@ _cc_sync_parse_dispatch_args() {
     rsync_options=()
     dry_run=false
     remote_spec=""
-    bounded_selector_mode=""
-    bounded_selector_value=""
+    find_args=""
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -391,8 +362,8 @@ _cc_sync_parse_dispatch_args() {
             shift
             ;;
         --modified-within)
-            if [ -n "$bounded_selector_mode" ]; then
-                echo "Bounded sync selectors are mutually exclusive."
+            if [ -n "$find_args" ]; then
+                echo "Only one file selection option may be specified."
                 return 1
             fi
             if [ $# -lt 2 ]; then
@@ -400,21 +371,19 @@ _cc_sync_parse_dispatch_args() {
                 return 1
             fi
             _cc_sync_validate_modified_within_days "$2" || return 1
-            bounded_selector_mode="modified_within_days"
-            bounded_selector_value="$2"
+            find_args="-type f -mtime -$2"
             shift 2
             ;;
         --find-args)
-            if [ -n "$bounded_selector_mode" ]; then
-                echo "Bounded sync selectors are mutually exclusive."
+            if [ -n "$find_args" ]; then
+                echo "Only one file selection option may be specified."
                 return 1
             fi
             if [ $# -lt 2 ]; then
                 echo "--find-args requires a value."
                 return 1
             fi
-            bounded_selector_mode="find_args"
-            bounded_selector_value="$2"
+            find_args="$2"
             shift 2
             ;;
         *)
@@ -463,7 +432,7 @@ _cc_sync_run_from() {
     shift 6
     local rsync_options=("$@")
     local remote_context_dir remote_context_path sync_source sync_destination
-    local bounded_result
+    local result
 
     _cc_sync_set_remote_context_vars "$remote_host" "$relative_path" || return 1
 
@@ -480,13 +449,13 @@ _cc_sync_run_from() {
     echo "Local context directory: $local_context_path"
     echo ""
 
-    if [ -n "$bounded_selector_mode" ]; then
-        _cc_sync_prepare_bounded_manifest from "$local_context_path" "$remote_host" "$remote_context_path" "$bounded_selector_mode" "$bounded_selector_value"
-        bounded_result=$?
+    if [ -n "$find_args" ]; then
+        _cc_sync_prepare_list_file from "$local_context_path" "$remote_host" "$remote_context_path" "$find_args"
+        result=$?
 
-        case "$bounded_result" in
+        case "$result" in
         0)
-            rsync_options+=("--files-from=$bounded_manifest_path")
+            rsync_options+=("--files-from=$list_file_path")
             ;;
         2)
             return 0
@@ -500,7 +469,7 @@ _cc_sync_run_from() {
     if [ "$dry_run" = false ] && _cc_sync_has_files_to_sync "${rsync_options[@]}" "$sync_source" "$sync_destination"; then
         if [ -d "$local_context_path" ]; then
             _cc_sync_backup "$local_context_path" "$local_context_dir" "$backup_dir" || {
-                _cc_sync_cleanup_bounded_manifest
+                _cc_sync_cleanup_list_file
                 return 1
             }
             echo ""
@@ -514,7 +483,7 @@ _cc_sync_run_from() {
     fi
     rsync -av "${rsync_options[@]}" "$sync_source" "$sync_destination"
     local rsync_status=$?
-    _cc_sync_cleanup_bounded_manifest
+    _cc_sync_cleanup_list_file
     [ "$rsync_status" -eq 0 ] || return "$rsync_status"
     echo "Done."
 }
@@ -530,7 +499,7 @@ _cc_sync_run_to() {
     local rsync_options=("$@")
     local remote_context_dir remote_context_path sync_source sync_destination
     local remote_context_exists=false
-    local bounded_result
+    local result
 
     if [ ! -d "$local_context_path" ]; then
         echo "$local_context_path does not exist on this machine"
@@ -554,13 +523,13 @@ _cc_sync_run_to() {
     echo "Local context directory: $local_context_path"
     echo ""
 
-    if [ -n "$bounded_selector_mode" ]; then
-        _cc_sync_prepare_bounded_manifest to "$local_context_path" "$remote_host" "$remote_context_path" "$bounded_selector_mode" "$bounded_selector_value"
-        bounded_result=$?
+    if [ -n "$find_args" ]; then
+        _cc_sync_prepare_list_file to "$local_context_path" "$remote_host" "$remote_context_path" "$find_args"
+        result=$?
 
-        case "$bounded_result" in
+        case "$result" in
         0)
-            rsync_options+=("--files-from=$bounded_manifest_path")
+            rsync_options+=("--files-from=$list_file_path")
             ;;
         2)
             return 0
@@ -574,7 +543,7 @@ _cc_sync_run_to() {
     if [ "$dry_run" = false ] && _cc_sync_has_files_to_sync "${rsync_options[@]}" "$sync_source" "$sync_destination"; then
         if [ "$remote_context_exists" = true ]; then
             _cc_sync_remote_backup "$remote_host" "$remote_context_dir" || {
-                _cc_sync_cleanup_bounded_manifest
+                _cc_sync_cleanup_list_file
                 return 1
             }
             echo ""
@@ -588,14 +557,14 @@ _cc_sync_run_to() {
     fi
     rsync -av "${rsync_options[@]}" "$sync_source" "$sync_destination"
     local rsync_status=$?
-    _cc_sync_cleanup_bounded_manifest
+    _cc_sync_cleanup_list_file
     [ "$rsync_status" -eq 0 ] || return "$rsync_status"
     echo "Done."
 }
 
 cc-sync() {
     local dispatch_command rsync_options dry_run remote_spec
-    local bounded_selector_mode bounded_selector_value bounded_manifest_path bounded_manifest_count
+    local find_args list_file_path
     local backup_dir current_dir local_context_dir local_context_path
     local sync_mode remote_host relative_path
 
@@ -615,8 +584,8 @@ cc-sync() {
 
     case $dispatch_command in
     backup | restore | pop)
-        if [ -n "$bounded_selector_mode" ]; then
-            echo "Bounded sync options are only supported with from/to."
+        if [ -n "$find_args" ]; then
+            echo "File selection is only supported with from/to."
             return 1
         fi
         if [ "${#rsync_options[@]}" -gt 0 ]; then
@@ -641,8 +610,8 @@ cc-sync() {
         esac
         ;;
     list | ls)
-        if [ -n "$bounded_selector_mode" ]; then
-            echo "Bounded sync options are only supported with from/to."
+        if [ -n "$find_args" ]; then
+            echo "File selection is only supported with from/to."
             return 1
         fi
         if [ "${#rsync_options[@]}" -gt 0 ]; then

--- a/claude-context.sh
+++ b/claude-context.sh
@@ -329,7 +329,8 @@ _cc_sync_prepare_bounded_manifest() {
     count=$(wc -l < "$bounded_manifest_path")
     bounded_manifest_count="${count//[[:space:]]/}"
 
-    echo "Selected ${bounded_manifest_count} files."
+    echo "Selected ${bounded_manifest_count} files:"
+    cat "$bounded_manifest_path"
 
     if [ "$bounded_manifest_count" -eq 0 ]; then
         echo "Nothing matched. Nothing to sync."

--- a/claude-context.sh
+++ b/claude-context.sh
@@ -170,11 +170,11 @@ _cc_sync_has_files_to_sync() {
 _cc_sync_validate_modified_within_days() {
     case "$1" in
     '' | *[!0-9]*)
-        echo "--modified-within-days requires a positive integer."
+        echo "--modified-within requires a positive integer."
         return 1
         ;;
     0)
-        echo "--modified-within-days requires a positive integer."
+        echo "--modified-within requires a positive integer."
         return 1
         ;;
     esac
@@ -219,7 +219,7 @@ _cc_sync_write_local_manifest() {
         modified_within_days)
             find . -type f -mtime -"${selector_value}" -print
             ;;
-        find_expr)
+        find_args)
             eval "find . ${selector_value}"
             ;;
         *)
@@ -258,7 +258,7 @@ case "$selector_mode" in
 modified_within_days)
     find . -type f -mtime -"${selector_value}" -print > "$raw_manifest_path"
     ;;
-find_expr)
+find_args)
     eval "find . ${selector_value}" > "$raw_manifest_path"
     ;;
 *)
@@ -389,13 +389,13 @@ _cc_sync_parse_dispatch_args() {
             rsync_options+=("$1")
             shift
             ;;
-        --modified-within-days)
+        --modified-within)
             if [ -n "$bounded_selector_mode" ]; then
                 echo "Bounded sync selectors are mutually exclusive."
                 return 1
             fi
             if [ $# -lt 2 ]; then
-                echo "--modified-within-days requires a value."
+                echo "--modified-within requires a value."
                 return 1
             fi
             _cc_sync_validate_modified_within_days "$2" || return 1
@@ -403,16 +403,16 @@ _cc_sync_parse_dispatch_args() {
             bounded_selector_value="$2"
             shift 2
             ;;
-        --find-expr)
+        --find-args)
             if [ -n "$bounded_selector_mode" ]; then
                 echo "Bounded sync selectors are mutually exclusive."
                 return 1
             fi
             if [ $# -lt 2 ]; then
-                echo "--find-expr requires a value."
+                echo "--find-args requires a value."
                 return 1
             fi
-            bounded_selector_mode="find_expr"
+            bounded_selector_mode="find_args"
             bounded_selector_value="$2"
             shift 2
             ;;

--- a/claude-context.sh
+++ b/claude-context.sh
@@ -167,11 +167,192 @@ _cc_sync_has_files_to_sync() {
     [ "$count" -gt 0 ]
 }
 
+_cc_sync_validate_modified_within_days() {
+    case "$1" in
+    '' | *[!0-9]*)
+        echo "--modified-within-days requires a positive integer."
+        return 1
+        ;;
+    0)
+        echo "--modified-within-days requires a positive integer."
+        return 1
+        ;;
+    esac
+}
+
+_cc_sync_normalize_manifest() {
+    local input_path="$1"
+    local output_path="$2"
+    local base_path="${3:-}"
+    local relative_path
+
+    : > "$output_path"
+
+    while IFS= read -r relative_path; do
+        relative_path="${relative_path#./}"
+
+        if [ -z "$relative_path" ]; then
+            continue
+        fi
+
+        if [ -n "$base_path" ] && [ ! -f "$base_path/$relative_path" ]; then
+            continue
+        fi
+
+        printf '%s\n' "$relative_path" >> "$output_path"
+    done < "$input_path"
+}
+
+_cc_sync_write_local_manifest() {
+    local context_path="$1"
+    local manifest_path="$2"
+    local selector_mode="$3"
+    local selector_value="$4"
+    local raw_manifest_path
+
+    raw_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-local-find.XXXXXX") || return 1
+
+    (
+        cd "$context_path" || exit 1
+
+        case "$selector_mode" in
+        modified_within_days)
+            find . -type f -mtime -"${selector_value}" -print
+            ;;
+        find_expr)
+            eval "find . ${selector_value}"
+            ;;
+        *)
+            echo "Unsupported bounded selector: $selector_mode"
+            exit 1
+            ;;
+        esac
+    ) > "$raw_manifest_path" || {
+        rm -f "$raw_manifest_path"
+        return 1
+    }
+
+    _cc_sync_normalize_manifest "$raw_manifest_path" "$manifest_path" "$context_path"
+    rm -f "$raw_manifest_path"
+}
+
+_cc_sync_write_remote_manifest() {
+    local remote_host="$1"
+    local remote_context_path="$2"
+    local manifest_path="$3"
+    local selector_mode="$4"
+    local selector_value="$5"
+    local raw_manifest_path
+
+    raw_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || return 1
+
+    ssh "$remote_host" sh -s -- "$remote_context_path" "$selector_mode" "$selector_value" <<'EOF' > "$raw_manifest_path" || {
+context_path="$1"
+selector_mode="$2"
+selector_value="$3"
+raw_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || exit 1
+
+cd "$context_path" || exit 1
+
+case "$selector_mode" in
+modified_within_days)
+    find . -type f -mtime -"${selector_value}" -print > "$raw_manifest_path"
+    ;;
+find_expr)
+    eval "find . ${selector_value}" > "$raw_manifest_path"
+    ;;
+*)
+    echo "Unsupported bounded selector: $selector_mode" >&2
+    rm -f "$raw_manifest_path"
+    exit 1
+    ;;
+esac
+
+while IFS= read -r relative_path; do
+    relative_path="${relative_path#./}"
+
+    if [ -z "$relative_path" ]; then
+        continue
+    fi
+
+    if [ ! -f "$relative_path" ]; then
+        continue
+    fi
+
+    printf '%s\n' "$relative_path"
+done < "$raw_manifest_path"
+
+rm -f "$raw_manifest_path"
+EOF
+        rm -f "$raw_manifest_path"
+        return 1
+    }
+
+    _cc_sync_normalize_manifest "$raw_manifest_path" "$manifest_path"
+    rm -f "$raw_manifest_path"
+}
+
+_cc_sync_prepare_bounded_manifest() {
+    local direction="$1"
+    local local_context_path="$2"
+    local remote_host="$3"
+    local remote_context_path="$4"
+    local selector_mode="$5"
+    local selector_value="$6"
+    local count
+
+    bounded_manifest_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-manifest.XXXXXX") || return 1
+
+    case "$direction" in
+    to)
+        _cc_sync_write_local_manifest "$local_context_path" "$bounded_manifest_path" "$selector_mode" "$selector_value" || {
+            rm -f "$bounded_manifest_path"
+            bounded_manifest_path=""
+            return 1
+        }
+        ;;
+    from)
+        _cc_sync_write_remote_manifest "$remote_host" "$remote_context_path" "$bounded_manifest_path" "$selector_mode" "$selector_value" || {
+            rm -f "$bounded_manifest_path"
+            bounded_manifest_path=""
+            return 1
+        }
+        ;;
+    *)
+        echo "Unsupported sync direction: $direction"
+        rm -f "$bounded_manifest_path"
+        bounded_manifest_path=""
+        return 1
+        ;;
+    esac
+
+    count=$(wc -l < "$bounded_manifest_path")
+    bounded_manifest_count="${count//[[:space:]]/}"
+
+    echo "Selected ${bounded_manifest_count} files."
+
+    if [ "$bounded_manifest_count" -eq 0 ]; then
+        echo "Nothing matched. Nothing to sync."
+        rm -f "$bounded_manifest_path"
+        bounded_manifest_path=""
+        return 2
+    fi
+}
+
+_cc_sync_cleanup_bounded_manifest() {
+    if [ -n "$bounded_manifest_path" ]; then
+        rm -f "$bounded_manifest_path"
+        bounded_manifest_path=""
+    fi
+}
+
 _cc_sync_parse_dispatch_args() {
     dispatch_command=""
     rsync_options=()
     dry_run=false
     remote_spec=""
+    bounded_selector_mode=""
+    bounded_selector_value=""
 
     while [[ $# -gt 0 ]]; do
         case $1 in
@@ -207,6 +388,33 @@ _cc_sync_parse_dispatch_args() {
         --delete | -z | --compress)
             rsync_options+=("$1")
             shift
+            ;;
+        --modified-within-days)
+            if [ -n "$bounded_selector_mode" ]; then
+                echo "Bounded sync selectors are mutually exclusive."
+                return 1
+            fi
+            if [ $# -lt 2 ]; then
+                echo "--modified-within-days requires a value."
+                return 1
+            fi
+            _cc_sync_validate_modified_within_days "$2" || return 1
+            bounded_selector_mode="modified_within_days"
+            bounded_selector_value="$2"
+            shift 2
+            ;;
+        --find-expr)
+            if [ -n "$bounded_selector_mode" ]; then
+                echo "Bounded sync selectors are mutually exclusive."
+                return 1
+            fi
+            if [ $# -lt 2 ]; then
+                echo "--find-expr requires a value."
+                return 1
+            fi
+            bounded_selector_mode="find_expr"
+            bounded_selector_value="$2"
+            shift 2
             ;;
         *)
             if [ -n "$remote_spec" ]; then
@@ -254,6 +462,7 @@ _cc_sync_run_from() {
     shift 6
     local rsync_options=("$@")
     local remote_context_dir remote_context_path sync_source sync_destination
+    local bounded_result
 
     _cc_sync_set_remote_context_vars "$remote_host" "$relative_path" || return 1
 
@@ -270,9 +479,29 @@ _cc_sync_run_from() {
     echo "Local context directory: $local_context_path"
     echo ""
 
+    if [ -n "$bounded_selector_mode" ]; then
+        _cc_sync_prepare_bounded_manifest from "$local_context_path" "$remote_host" "$remote_context_path" "$bounded_selector_mode" "$bounded_selector_value"
+        bounded_result=$?
+
+        case "$bounded_result" in
+        0)
+            rsync_options+=("--files-from=$bounded_manifest_path")
+            ;;
+        2)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+        esac
+    fi
+
     if [ "$dry_run" = false ] && _cc_sync_has_files_to_sync "${rsync_options[@]}" "$sync_source" "$sync_destination"; then
         if [ -d "$local_context_path" ]; then
-            _cc_sync_backup "$local_context_path" "$local_context_dir" "$backup_dir" || return 1
+            _cc_sync_backup "$local_context_path" "$local_context_dir" "$backup_dir" || {
+                _cc_sync_cleanup_bounded_manifest
+                return 1
+            }
             echo ""
         fi
     fi
@@ -283,6 +512,9 @@ _cc_sync_run_from() {
         echo "Syncing from $remote_host..."
     fi
     rsync -av "${rsync_options[@]}" "$sync_source" "$sync_destination"
+    local rsync_status=$?
+    _cc_sync_cleanup_bounded_manifest
+    [ "$rsync_status" -eq 0 ] || return "$rsync_status"
     echo "Done."
 }
 
@@ -297,6 +529,7 @@ _cc_sync_run_to() {
     local rsync_options=("$@")
     local remote_context_dir remote_context_path sync_source sync_destination
     local remote_context_exists=false
+    local bounded_result
 
     if [ ! -d "$local_context_path" ]; then
         echo "$local_context_path does not exist on this machine"
@@ -320,9 +553,29 @@ _cc_sync_run_to() {
     echo "Local context directory: $local_context_path"
     echo ""
 
+    if [ -n "$bounded_selector_mode" ]; then
+        _cc_sync_prepare_bounded_manifest to "$local_context_path" "$remote_host" "$remote_context_path" "$bounded_selector_mode" "$bounded_selector_value"
+        bounded_result=$?
+
+        case "$bounded_result" in
+        0)
+            rsync_options+=("--files-from=$bounded_manifest_path")
+            ;;
+        2)
+            return 0
+            ;;
+        *)
+            return 1
+            ;;
+        esac
+    fi
+
     if [ "$dry_run" = false ] && _cc_sync_has_files_to_sync "${rsync_options[@]}" "$sync_source" "$sync_destination"; then
         if [ "$remote_context_exists" = true ]; then
-            _cc_sync_remote_backup "$remote_host" "$remote_context_dir" || return 1
+            _cc_sync_remote_backup "$remote_host" "$remote_context_dir" || {
+                _cc_sync_cleanup_bounded_manifest
+                return 1
+            }
             echo ""
         fi
     fi
@@ -333,11 +586,15 @@ _cc_sync_run_to() {
         echo "Syncing to $remote_host..."
     fi
     rsync -av "${rsync_options[@]}" "$sync_source" "$sync_destination"
+    local rsync_status=$?
+    _cc_sync_cleanup_bounded_manifest
+    [ "$rsync_status" -eq 0 ] || return "$rsync_status"
     echo "Done."
 }
 
 cc-sync() {
     local dispatch_command rsync_options dry_run remote_spec
+    local bounded_selector_mode bounded_selector_value bounded_manifest_path bounded_manifest_count
     local backup_dir current_dir local_context_dir local_context_path
     local sync_mode remote_host relative_path
 
@@ -357,6 +614,10 @@ cc-sync() {
 
     case $dispatch_command in
     backup | restore | pop)
+        if [ -n "$bounded_selector_mode" ]; then
+            echo "Bounded sync options are only supported with from/to."
+            return 1
+        fi
         if [ "${#rsync_options[@]}" -gt 0 ]; then
             echo "Unexpected rsync option."
             return 1
@@ -379,6 +640,10 @@ cc-sync() {
         esac
         ;;
     list | ls)
+        if [ -n "$bounded_selector_mode" ]; then
+            echo "Bounded sync options are only supported with from/to."
+            return 1
+        fi
         if [ "${#rsync_options[@]}" -gt 0 ]; then
             echo "Unexpected rsync option."
             return 1

--- a/claude-context.sh
+++ b/claude-context.sh
@@ -186,7 +186,7 @@ _cc_sync_normalize_list_file() {
     local base_path="${3:-}"
     local relative_path
 
-    : > "$output_path"
+    : >"$output_path"
 
     while IFS= read -r relative_path; do
         relative_path="${relative_path#./}"
@@ -199,8 +199,8 @@ _cc_sync_normalize_list_file() {
             continue
         fi
 
-        printf '%s\n' "$relative_path" >> "$output_path"
-    done < "$input_path"
+        printf '%s\n' "$relative_path" >>"$output_path"
+    done <"$input_path"
 }
 
 _cc_sync_write_local_list_file() {
@@ -214,7 +214,7 @@ _cc_sync_write_local_list_file() {
     (
         cd "$context_path" || exit 1
         eval "find . ${find_args}"
-    ) > "$raw_output_path" || {
+    ) >"$raw_output_path" || {
         rm -f "$raw_output_path"
         return 1
     }
@@ -232,7 +232,7 @@ _cc_sync_write_remote_list_file() {
 
     raw_output_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || return 1
 
-    ssh "$remote_host" sh -s -- "$remote_context_path" "$find_args" <<'EOF' > "$raw_output_path" || {
+    ssh "$remote_host" sh -s -- "$remote_context_path" "$find_args" <<'EOF' >"$raw_output_path" || {
 context_path="$1"
 find_args="$2"
 raw_output_path=$(mktemp "${TMPDIR:-/tmp}/cc-sync-remote-find.XXXXXX") || exit 1
@@ -298,7 +298,7 @@ _cc_sync_prepare_list_file() {
         ;;
     esac
 
-    file_count=$(wc -l < "$list_file_path")
+    file_count=$(wc -l <"$list_file_path")
     file_count="${file_count//[[:space:]]/}"
 
     echo "Selected ${file_count} files:"
@@ -585,7 +585,7 @@ cc-sync() {
     case $dispatch_command in
     backup | restore | pop)
         if [ -n "$find_args" ]; then
-            echo "File selection is only supported with from/to."
+            echo "File selection is only supported for sync operations."
             return 1
         fi
         if [ "${#rsync_options[@]}" -gt 0 ]; then
@@ -611,7 +611,7 @@ cc-sync() {
         ;;
     list | ls)
         if [ -n "$find_args" ]; then
-            echo "File selection is only supported with from/to."
+            echo "File selection is only supported for sync operations."
             return 1
         fi
         if [ "${#rsync_options[@]}" -gt 0 ]; then


### PR DESCRIPTION
  ## Summary

  Add `find -type f` selection to `cc-sync`

  - add `--find-args "<args>"` for advanced `find`-based selection
  - add `--modified-within <days>` as shorthand for `find . -type f -mtime -<days>`

  ## Validation

  - zsh -n claude-context.sh
  - bash -n claude-context.sh
  - dry-run simulation for to --modified-within 7 confirmed a list file is passed to rsync
  - dry-run simulation for from --find-args "-type f -name '*.jsonl'" confirmed remote file selection is materialized locally and passed
  via --files-from
  - empty-selection simulation confirmed success without invoking rsync
  - invalid-usage simulation confirmed file selection options are rejected for list